### PR TITLE
Vim crash

### DIFF
--- a/wssh/client.py
+++ b/wssh/client.py
@@ -13,6 +13,8 @@ import struct
 
 import platform
 
+from wssh.encoding import encode, decode
+
 try:
     import simplejson as json
 except ImportError:
@@ -68,13 +70,13 @@ def invoke_shell(endpoint):
                     message = json.loads(data)
                     if 'error' in message:
                         raise ConnectionError(message['error'])
-                    sys.stdout.write(message['data'])
+                    sys.stdout.write(decode(message['data']))
                     sys.stdout.flush()
                 if sys.stdin in r:
                     x = sys.stdin.read(1)
                     if len(x) == 0:
                         break
-                    ssh.send(json.dumps({'data': x}))
+                    ssh.send(json.dumps({'data': encode(x)}))
             except (select.error, IOError) as e:
                 if e.args and e.args[0] == errno.EINTR:
                     pass

--- a/wssh/client.py
+++ b/wssh/client.py
@@ -70,7 +70,7 @@ def invoke_shell(endpoint):
                     message = json.loads(data)
                     if 'error' in message:
                         raise ConnectionError(message['error'])
-                    sys.stdout.write(decode(message['data']))
+                    sys.stdout.buffer.write(decode(message['data']))
                     sys.stdout.flush()
                 if sys.stdin in r:
                     x = sys.stdin.read(1)

--- a/wssh/encoding.py
+++ b/wssh/encoding.py
@@ -1,7 +1,10 @@
 import base64
+import six
 
 
 def encode(data):
+    if isinstance(data, six.string_types):
+        data = bytes(data, 'utf-8')
     return str(base64.b64encode(data), 'utf-8')
 
 

--- a/wssh/encoding.py
+++ b/wssh/encoding.py
@@ -1,0 +1,9 @@
+import base64
+
+
+def encode(data):
+    return str(base64.b64encode(data), 'utf-8')
+
+
+def decode(data):
+    return base64.b64decode(bytearray(data, 'utf-8'))

--- a/wssh/server.py
+++ b/wssh/server.py
@@ -125,7 +125,7 @@ class WSSHBridge(object):
                         data['resize'].get('width', 80),
                         data['resize'].get('height', 24))
                 if 'data' in data:
-                    channel.send(encode(data['data']))
+                    channel.send(decode(data['data']))
         finally:
             self.close()
 

--- a/wssh/server.py
+++ b/wssh/server.py
@@ -20,6 +20,8 @@ from paramiko.ssh_exception import SSHException
 
 import socket
 
+from wssh.encoding import encode, decode
+
 try:
     import simplejson as json
 except ImportError:
@@ -123,7 +125,7 @@ class WSSHBridge(object):
                         data['resize'].get('width', 80),
                         data['resize'].get('height', 24))
                 if 'data' in data:
-                    channel.send(data['data'].encode('utf-8'))
+                    channel.send(encode(data['data']))
         finally:
             self.close()
 
@@ -139,7 +141,7 @@ class WSSHBridge(object):
 
                 data += recv
                 try:
-                    self._websocket.send(json.dumps({'data': data}))
+                    self._websocket.send(json.dumps({'data': encode(data)}))
                     data = ''
                 except UnicodeDecodeError:
                     pass

--- a/wssh/server.py
+++ b/wssh/server.py
@@ -132,7 +132,7 @@ class WSSHBridge(object):
     def _forward_outbound(self, channel):
         """ Forward outbound traffic (ssh -> websockets) """
         try:
-            data = ''
+            data = b''
             while True:
                 wait_read(channel.fileno())
                 recv = channel.recv(1024)
@@ -142,7 +142,7 @@ class WSSHBridge(object):
                 data += recv
                 try:
                     self._websocket.send(json.dumps({'data': encode(data)}))
-                    data = ''
+                    data = b''
                 except UnicodeDecodeError:
                     pass
         finally:

--- a/wssh/static/term.js
+++ b/wssh/static/term.js
@@ -129,9 +129,10 @@ function Terminal(cols, rows, handler) {
 
   this.cols = cols || Terminal.geometry[0];
   this.rows = rows || Terminal.geometry[1];
+  this.handler = handler;
 
-  if (handler) {
-    this.on('data', handler);
+  if (this.handler) {
+    this.on('data', this.handler);
   }
 
   this.ybase = 0;
@@ -2432,7 +2433,7 @@ Terminal.prototype.reverseIndex = function() {
 
 // ESC c Full Reset (RIS).
 Terminal.prototype.reset = function() {
-  Terminal.call(this, this.cols, this.rows);
+  Terminal.call(this, this.cols, this.rows, this.handler);
   this.refresh(0, this.rows - 1);
 };
 


### PR DESCRIPTION
This breaks the js client, but fixes the python client's handling of unicode.

Using json is stupid and I'm going to tear it out eventually. Or switch to a different library entirely.
